### PR TITLE
fix: batches being removed from `ModelInstance` after device transfer

### DIFF
--- a/src/f21nl/datamodule.py
+++ b/src/f21nl/datamodule.py
@@ -212,3 +212,11 @@ class Multi30kDataModule(LightningDataModule):
             drop_last=False,
             collate_fn=CollateFn(),
         )
+
+    def on_after_batch_transfer(self, batch: tuple[torch.Tensor | None, ...], dataloader_idx: int) -> ModelInstance:
+        """Convert the batch to a ModelInstance.
+
+        When transfers the batch to the device, the batch is converted to a tuple of tensors from
+        the `ModelInstance` class. This method converts the batch back to a `ModelInstance` object.
+        """
+        return ModelInstance(*batch)


### PR DESCRIPTION
Recent reports of an error has meant that the trainer has started failing during the sanity checking step, and is also a problem with other steps too. I don't know why this has started happening but here we are I guess. 

```python
│                                                                                                  │
│ /usr/local/lib/python3.10/dist-packages/f21nl/lightning_modules/nmt_seq2seq.py:227 in            │
│ validation_step                                                                                  │
│                                                                                                  │
│   224 │   │   will likely be similar to the `training_step`, but it also might not be.           │
│   225 │   │   """                                                                                │
│   226 │   │   output_dict = self.forward(                                                        │
│ ❱ 227 │   │   │   batch.source_tokens, batch.source_attention_mask, batch.target_tokens          │
│   228 │   │   )                                                                                  │
│   229 │   │                                                                                      │
│   230 │   │   loss = self._get_loss(                                                             │
│                                                                                                  │
│ ╭─────────────────────────────────────────── locals ───────────────────────────────────────────╮ │
│ │ batch = (                                                                                    │ │
│ │         │   tensor([[   3,   37,   11,   29,   16, 1639, 2462,  338,    3,  278,    0,    0, │ │
│ │         │   │   │   0,    0],                                                                │ │
│ │         │   │   [   3,    8,  377,    5,    3,   51,  189,    7,    3,  427,    4,    0,     │ │
│ │         │   │   │   0,    0],                                                                │ │
│ │         │   │   [   3,   33,   21,  739,   93,    7,    3,   13,   62,   91,   59,  101,     │ │
│ │         │   │     877,    4],                                                                │ │
│ │         │   │   [  15,   29,  402,   50,    3,   28,  263,  379, 1893,    7,   20, 5145,     │ │
│ │         │   │      77,  320]], device='cuda:0'),                                             │ │
│ │         │   tensor([[ True,  True,  True,  True,  True,  True,  True,  True,  True,  True,   │ │
│ │         │   │    False, False, False, False],                                                │ │
│ │         │   │   [ True,  True,  True,  True,  True,  True,  True,  True,  True,  True,       │ │
│ │         │   │     True, False, False, False],                                                │ │
│ │         │   │   [ True,  True,  True,  True,  True,  True,  True,  True,  True,  True,       │ │
│ │         │   │     True,  True,  True,  True],                                                │ │
│ │         │   │   [ True,  True,  True,  True,  True,  True,  True,  True,  True,  True,       │ │
│ │         │   │     True,  True,  True,  True]], device='cuda:0'),                             │ │
│ │         │   tensor([[   0,    3,   38,   11,    7,    8,    6,   35, 4151,   37, 5223,   12, │ │
│ │         │   │   │   3,  272,    1,    0,    0,    0,    0],                                  │ │
│ │         │   │   [   0,    3,   14, 1126,   12,    5, 1090,  181,   13,    3,  376,    4,     │ │
│ │         │   │   │   1,    0,    0,    0,    0,    0,    0],                                  │ │
│ │         │   │   [   0,    3,   40,   17,    3,  177,   26,   41,   13,   39,  796,   11,     │ │
│ │         │   │   │   7,    8,    6,    5,   21,    4,    1],                                  │ │
│ │         │   │   [   0,   23,   35, 1993,    5,  252,    9,  416,   13,  329,  113,   13,     │ │
│ │         │   │   │   3,  311, 3676,    1,    0,    0,    0]], device='cuda:0'),               │ │
│ │         │   tensor([[ True,  True,  True,  True,  True,  True,  True,  True,  True,  True,   │ │
│ │         │   │     True,  True,  True,  True,  True, False, False, False, False],             │ │
│ │         │   │   [ True,  True,  True,  True,  True,  True,  True,  True,  True,  True,       │ │
│ │         │   │     True,  True,  True, False, False, False, False, False, False],             │ │
│ │         │   │   [ True,  True,  True,  True,  True,  True,  True,  True,  True,  True,       │ │
│ │         │   │     True,  True,  True,  True,  True,  True,  True,  True,  True],             │ │
│ │         │   │   [ True,  True,  True,  True,  True,  True,  True,  True,  True,  True,       │ │
│ │         │   │     True,  True,  True,  True,  True,  True, False, False, False]],            │ │
│ │         │      device='cuda:0')                                                              │ │
│ │         )                                                                                    │ │
│ │  self = CustomNMTModule(                                                                     │ │
│ │           (loss_function): CrossEntropyLoss()                                                │ │
│ │           (_bleu): BLEUScore()                                                               │ │
│ │           (model): CustomNMTEncoderDecoder(                                                  │ │
│ │         │   (encoder): NMTEncoder(                                                           │ │
│ │         │     (embeddings): Embedding(9781, 50)                                              │ │
│ │         │     (_encoder): LSTM(50, 200, bidirectional=True)                                  │ │
│ │         │   )                                                                                │ │
│ │         │   (decoder): NMTDecoder(                                                           │ │
│ │         │     (embeddings): Embedding(11026, 50)                                             │ │
│ │         │     (_decoder_cell): LSTMCell(50, 400)                                             │ │
│ │         │   )                                                                                │ │
│ │         │   (_output_projection_layer): Linear(in_features=400, out_features=11026,          │ │
│ │         bias=True)                                                                           │ │
│ │           )                                                                                  │ │
│ │         )                                                                                    │ │
│ ╰──────────────────────────────────────────────────────────────────────────────────────────────╯ │
╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
AttributeError: 'tuple' object has no attribute 'source_tokens'
```


For some reason, after transfer the `ModelInstance` to the device, it becomes a plain tuple and not an instance of the `ModelInstance`, causing the above error. I've solved this by converting the tuple back into the `ModelInstance` using the `on_after_batch_transfer()` hook in the DataModule. I verified it by creating a new inherited class and adding the hook in the CW notebook and trying it and it worked.[^1]

[^1]: I had the full traceback and more words and code snippets for my monkeypatched solution but when I tried to submit the PR before, it was too long and it deleted everything I wrote before. 