### PR TITLE
fix: support other decoding implementations

### DIFF
--- a/src/f21nl/model_components/encoder_decoder.py
+++ b/src/f21nl/model_components/encoder_decoder.py
@@ -51,8 +51,12 @@ class NMTEncoderDecoder(nn.Module):
 
         if config.decoding_strategy.name == "greedy":
             self.decode_strategy = GreedyDecoding()
+        elif config.decoding_strategy.name in {"top_k", "top_p"}:
+            pass
         else:
-            raise NotImplementedError("You still haven't implemented your decoding strategy!")
+            raise NotImplementedError(
+                f"Decoding strategy not supported: {config.decoding_strategy.name}!"
+            )
 
     def take_step(
         self, last_predictions: torch.Tensor, state: dict[str, torch.Tensor]


### PR DESCRIPTION
This was a silly bug that was highlighted in the discussion forum (and clarified in today's lecture).

The idea is to simply ignore when the user passes `top_k` or `top_p` as decoding strategy instead of raising an exception.